### PR TITLE
feat(assignment): verify and document assignment feature architecture

### DIFF
--- a/lib/src/core/di/injection.config.dart
+++ b/lib/src/core/di/injection.config.dart
@@ -49,6 +49,8 @@ import 'package:form_gear_engine_sdk/src/domain/repositories/download_repository
     as _i170;
 import 'package:form_gear_engine_sdk/src/domain/repositories/file_repository.dart'
     as _i260;
+import 'package:form_gear_engine_sdk/src/domain/repositories/form_data_repository.dart'
+    as _i771;
 import 'package:form_gear_engine_sdk/src/domain/repositories/form_engine_repository.dart'
     as _i458;
 import 'package:form_gear_engine_sdk/src/domain/repositories/template_repository.dart'
@@ -67,6 +69,8 @@ import 'package:form_gear_engine_sdk/src/domain/usecases/extract_form_engine_use
     as _i356;
 import 'package:form_gear_engine_sdk/src/domain/usecases/extract_template_usecase.dart'
     as _i87;
+import 'package:form_gear_engine_sdk/src/domain/usecases/get_assignment_usecase.dart'
+    as _i1048;
 import 'package:form_gear_engine_sdk/src/domain/usecases/get_custom_template_data_usecase.dart'
     as _i732;
 import 'package:form_gear_engine_sdk/src/domain/usecases/get_local_form_engine_version_usecase.dart'
@@ -81,6 +85,8 @@ import 'package:form_gear_engine_sdk/src/domain/usecases/save_form_engine_versio
     as _i58;
 import 'package:form_gear_engine_sdk/src/domain/usecases/save_template_version_usecase.dart'
     as _i980;
+import 'package:form_gear_engine_sdk/src/domain/usecases/update_assignment_usecase.dart'
+    as _i518;
 import 'package:get_it/get_it.dart' as _i174;
 import 'package:injectable/injectable.dart' as _i526;
 
@@ -104,6 +110,12 @@ _i174.GetIt $initGetIt(
   );
   gh.lazySingleton<_i422.ZipRepository>(
     () => _i542.ZipRepositoryImpl(fileRepository: gh<_i260.FileRepository>()),
+  );
+  gh.lazySingleton<_i518.UpdateAssignmentUseCase>(
+    () => _i518.UpdateAssignmentUseCase(gh<_i771.FormDataRepository>()),
+  );
+  gh.lazySingleton<_i1048.GetAssignmentUseCase>(
+    () => _i1048.GetAssignmentUseCase(gh<_i771.FormDataRepository>()),
   );
   gh.lazySingleton<_i174.EncryptionService>(
     () => _i174.EncryptionService(customKey: gh<String>()),

--- a/lib/src/domain/usecases/get_assignment_usecase.dart
+++ b/lib/src/domain/usecases/get_assignment_usecase.dart
@@ -2,9 +2,11 @@ import 'package:form_gear_engine_sdk/src/core/base/base_use_case.dart';
 import 'package:form_gear_engine_sdk/src/core/base/result.dart';
 import 'package:form_gear_engine_sdk/src/domain/repositories/form_data_repository.dart';
 import 'package:form_gear_engine_sdk/src/models/assignment.dart';
+import 'package:injectable/injectable.dart';
 
 /// Use case for getting assignment by ID
 /// Encapsulates business logic for assignment retrieval
+@lazySingleton
 class GetAssignmentUseCase
     extends BaseUseCase<Result<Assignment>, String, FormDataRepository> {
   const GetAssignmentUseCase(super.repo);

--- a/lib/src/domain/usecases/update_assignment_usecase.dart
+++ b/lib/src/domain/usecases/update_assignment_usecase.dart
@@ -2,9 +2,11 @@ import 'package:form_gear_engine_sdk/src/core/base/base_use_case.dart';
 import 'package:form_gear_engine_sdk/src/core/base/result.dart';
 import 'package:form_gear_engine_sdk/src/domain/repositories/form_data_repository.dart';
 import 'package:form_gear_engine_sdk/src/models/assignment.dart';
+import 'package:injectable/injectable.dart';
 
 /// Use case for updating assignment
 /// Encapsulates business logic for assignment updates
+@lazySingleton
 class UpdateAssignmentUseCase
     extends BaseUseCase<Result<bool>, Assignment, FormDataRepository> {
   const UpdateAssignmentUseCase(super.repo);


### PR DESCRIPTION
## Summary

This PR verifies and documents the assignment feature architecture, clarifying that the SDK's role is to **receive** assignment context from the FASIH app, not to persist assignments itself.

## Changes

- ✅ **Added `@lazySingleton` annotations** to `GetAssignmentUseCase` and `UpdateAssignmentUseCase`
- ✅ **Regenerated dependency injection configuration**
- ✅ **Verified assignment feature architecture** follows FASIH integration patterns

## Architecture Verification

### ✅ Assignment Feature is Complete

The assignment feature is **fully implemented** with the correct architecture:

1. **FASIH app provides assignment data** via `AssignmentContext`
2. **SDK displays form** using `openFormWithAssignment()`
3. **SDK calls FormDataListener** on save/submit operations
4. **FASIH app handles persistence** (not SDK's responsibility)

### 📋 What's Already Implemented

- ✅ `AssignmentContext` model with dynamic configuration
- ✅ `AssignmentConfig` for per-assignment settings
- ✅ `AssignmentData` for template, validation, responses, media
- ✅ `openFormWithAssignment()` method in FormGearSDK
- ✅ Assignment-aware JavaScript handlers
- ✅ `AssignmentDemoScreen` with 3 working scenarios
- ✅ Connected to home screen navigation

### 🎯 Integration Pattern (FASIH-Compatible)

```dart
// 1. FASIH app creates assignment with all data
final assignment = AssignmentContext(
  assignmentId: 'assignment_001',
  templateId: 'template_001',
  surveyId: 'survey_2024',
  config: AssignmentConfig(
    lookupMode: FormGearLookupMode.online,
    formMode: FormGearFormMode.open,
    clientMode: FormGearClientMode.capi,
  ),
  data: AssignmentData(
    template: {/* from FASIH storage */},
    validation: {/* from FASIH storage */},
    response: {/* existing responses */},
    media: {/* media files */},
  ),
);

// 2. SDK opens form
await FormGearSDK.instance.openFormWithAssignment(
  context: context,
  assignment: assignment,
);

// 3. SDK calls listener on save/submit
// 4. FASIH app handles all persistence
```

## Test Plan

- [x] Flutter analyze passes with no issues
- [x] Build_runner regenerates DI config successfully
- [x] Assignment demo screen works correctly
- [x] All 3 assignment scenarios functional (new, existing, review)
- [x] FASIH integration architecture documented

## References

- FASIH_INTEGRATION_ANALYSIS.md confirms assignment management is FASIH app responsibility
- AssignmentDemoScreen provides complete working examples
- CLAUDE.md documents assignment-based configuration patterns